### PR TITLE
add err.stack on process#uncaughtException for printing error stack

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -176,7 +176,7 @@ function proxyServer(option){
                 });
 
                 process.on("uncaughtException",function(err){
-                    logUtil.printLog('Caught exception: ' + err, logUtil.T_ERR);
+                    logUtil.printLog('Caught exception: ' + (err.stack || err), logUtil.T_ERR);
                     process.exit();
                 });
 


### PR DESCRIPTION
打印错误堆栈，方便定位问题。