### PR TITLE
Correctly parse url for https if port is not 443.

### DIFF
--- a/lib/requestHandler.js
+++ b/lib/requestHandler.js
@@ -20,9 +20,10 @@ var defaultRule = require("./rule_default.js"),
 function userRequestHandler(req,userRes){
 
     var host               = req.headers.host,
-        urlPattern         = url.parse(req.url),
-        path               = urlPattern.path,
         protocol           = (!!req.connection.encrypted && !/^http:/.test(req.url)) ? "https" : "http",
+        fullUrl            = protocol + '://' + host + req.url,
+        urlPattern         = url.parse(fullUrl),
+        path               = urlPattern.path,
         resourceInfo,
         resourceInfoId     = -1,
         reqData;

--- a/lib/requestHandler.js
+++ b/lib/requestHandler.js
@@ -21,7 +21,7 @@ function userRequestHandler(req,userRes){
 
     var host               = req.headers.host,
         protocol           = (!!req.connection.encrypted && !/^http:/.test(req.url)) ? "https" : "http",
-        fullUrl            = protocol + '://' + host + req.url,
+        fullUrl            = protocol === "http" ? req.url : (protocol + '://' + host + req.url),
         urlPattern         = url.parse(fullUrl),
         path               = urlPattern.path,
         resourceInfo,


### PR DESCRIPTION
HTTPs interception seems only work for the default port 443. Now it should be able to correctly parse the url for any port.