### PR TITLE
tune css in overlay, make it easier to read the request/resposne

### DIFF
--- a/web/css/page.css
+++ b/web/css/page.css
@@ -232,14 +232,13 @@ body, html {
 }
 
 .recordDetailOverlay li{
-	white-space: nowrap;
 	word-wrap: break-word;
 }
 
 .recordDetailOverlay iframe{
 	position: relative;
 	height: 92vh;
-	width: 100%; 
+	width: 100%;
 }
 
 .data_id{
@@ -354,4 +353,3 @@ body, html {
 
 
 /*map panel end*/
-


### PR DESCRIPTION
A lot of the requests have very long url+params, current css make it very hard to read/copy-paste.

Remove the white-space: nowrap to make it more friendly to user.