### PR TITLE
add callback for function proxyServer

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -51,8 +51,9 @@ var default_rule = require('./lib/rule_default');
 //option.disableWebInterface
 //option.silent        : false(default)
 //option.interceptHttps ,internal param for https
-function proxyServer(option){
+function proxyServer(option, cb){
     option = option || {};
+    cb = cb || function() {}
 
     var self       = this,
         proxyType           = /https/i.test(option.type || DEFAULT_TYPE) ? T_TYPE_HTTPS : T_TYPE_HTTP ,
@@ -190,6 +191,7 @@ function proxyServer(option){
                 logUtil.printLog(color.red(tipText), logUtil.T_ERR);
                 logUtil.printLog(err, logUtil.T_ERR);
             }
+            cb()
         }
     );
 


### PR DESCRIPTION
Hi, just add callback for function proxyServer. So can start multiple proxy like this:

```
  console.log('-----------------------------------------------------------')
  proxy.proxyServer(options1, function() {
    console.log('-----------------------------------------------------------')
    proxy.proxyServer(options2, function() {
      console.log('-----------------------------------------------------------')
    })
  })
```
