### PR TITLE
modify `notBefore`

### DIFF
--- a/lib/certGenerator.js
+++ b/lib/certGenerator.js
@@ -13,8 +13,9 @@ function getKeysAndCert(){
   cert.publicKey = keys.publicKey;
   cert.serialNumber = '01';
   cert.validity.notBefore = new Date();
+  cert.validity.notBefore.setFullYear(cert.validity.notBefore.getFullYear() - 10); // 10 years
   cert.validity.notAfter = new Date();
-  cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 10); // 10 years
+  cert.validity.notAfter.setFullYear(cert.validity.notAfter.getFullYear() + 10); // 10 years
   return {
     keys: keys,
     cert: cert


### PR DESCRIPTION
证书时间戳notBefore
的时间最好设置早点。当用户使用其它设备安装ca证书连接代理时，可能由于该设备的时间设置比生成证书的设备慢，会导致系统判定证书还未生效。