### PR TITLE
修复windows下 home路径不正确的问题

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -24,7 +24,7 @@ module.exports.merge = function(baseObj, extendObj){
 }
 
 function getUserHome(){
-    return process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
+    return process.env.HOME || process.env.USERPROFILE;
 }
 module.exports.getUserHome = getUserHome;
 


### PR DESCRIPTION
windows下 HOMEPATH不包含盘符，会导致出错。建议直接使用USERPROFILE