### PR TITLE
Content-Type application/json interface fix

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -149,12 +149,10 @@ function Recorder() {
               if (currentCharset !== 'utf-8' && iconv.encodingExists(currentCharset)) {
                 bodyContent = iconv.decode(bodyContent, currentCharset);
               }
-            }
 
-            if (contentType && /application\/json/i.test(contentType)) {
-              result.type = 'json';
               result.mime = contentType;
               result.content = bodyContent.toString();
+              result.type = contentType && /application\/json/i.test(contentType) ? 'json' : 'text';
             } else if (contentType && /image/i.test(contentType)) {
               result.type = 'image';
               result.mime = contentType;

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -149,10 +149,12 @@ function Recorder() {
               if (currentCharset !== 'utf-8' && iconv.encodingExists(currentCharset)) {
                 bodyContent = iconv.decode(bodyContent, currentCharset);
               }
+            }
 
+            if (contentType && /application\/json/i.test(contentType)) {
+              result.type = 'json';
               result.mime = contentType;
               result.content = bodyContent.toString();
-              result.type = contentType && /application\/json/i.test(contentType) ? 'json' : 'text';
             } else if (contentType && /image/i.test(contentType)) {
               result.type = 'image';
               result.mime = contentType;


### PR DESCRIPTION
When response Content-Type is "application/json" and Header without "charset", WebInterface can not show Source/Preview in response tab.