### PR TITLE
fix the "write after end" error when in stream mode

### DIFF
--- a/lib/requestHandler.js
+++ b/lib/requestHandler.js
@@ -159,7 +159,7 @@ function fetchRemoteResponse(protocol, options, reqData, config) {
 
       res.on('end', () => {
         if (resDataStream) {
-          resDataStream.emit('end'); // EOF
+          resDataStream.push(null); // indicate the stream is end
         } else {
           finishCollecting();
         }


### PR DESCRIPTION
When AnyProxy handles a large response file, it will turns into stream mode, pipe the strem into response directly. 

This pr is to fix the error when the "end event" is emitted ahead of the actual end of "response stream"