### PR TITLE
typo: 大小写敏感的操作系统下, require('AnyProxy')会导致模块找不到的错误。

### DIFF
--- a/docs-src/cn/README.md
+++ b/docs-src/cn/README.md
@@ -164,7 +164,7 @@ proxyServer.close();
   * 样例
 
   ```js
-    const AnyProxy = require('AnyProxy');
+    const AnyProxy = require('anyproxy');
     const exec = require('child_process').exec;
 
     if (!AnyProxy.utils.certMgr.ifRootCAFileExists()) {
@@ -528,8 +528,8 @@ module.exports = {
 anyproxy --rule rule_sample/sample_use_local_response.js
 ```
 ```js
-/* 
-  sample: 
+/*
+  sample:
     intercept all requests toward httpbin.org, use a local response
   test:
     curl http://httpbin.org/user-agent --proxy http://127.0.0.1:8001
@@ -558,8 +558,8 @@ module.exports = {
 anyproxy --rule rule_sample/sample_modify_request_header.js
 ```
 ```js
-/* 
-  sample: 
+/*
+  sample:
     modify the user-agent in requests toward httpbin.org
   test:
     curl http://httpbin.org/user-agent --proxy http://127.0.0.1:8001
@@ -647,8 +647,8 @@ module.exports = {
 anyproxy --rule rule_sample/sample_modify_request_protocol.js
 ```
 ```js
-/* 
-  sample: 
+/*
+  sample:
     redirect all http requests of httpbin.org to https
   test:
     curl 'http://httpbin.org/get?show_env=1' --proxy http://127.0.0.1:8001
@@ -677,8 +677,8 @@ module.exports = {
 anyproxy --rule rule_sample/sample_modify_response_statuscode.js
 ```
 ```js
-/* 
-  sample: 
+/*
+  sample:
     modify all status code of http://httpbin.org/ to 404
   test:
     curl -I 'http://httpbin.org/user-agent' --proxy http://127.0.0.1:8001
@@ -706,8 +706,8 @@ module.exports = {
 anyproxy --rule rule_sample/sample_modify_response_header.js
 ```
 ```js
-/* 
-  sample: 
+/*
+  sample:
     modify response header of http://httpbin.org/user-agent
   test:
     curl -I 'http://httpbin.org/user-agent' --proxy http://127.0.0.1:8001
@@ -735,8 +735,8 @@ module.exports = {
 anyproxy --rule rule_sample/sample_modify_response_data.js
 ```
 ```js
-/* 
-  sample: 
+/*
+  sample:
     modify response data of http://httpbin.org/user-agent
   test:
     curl 'http://httpbin.org/user-agent' --proxy http://127.0.0.1:8001

--- a/docs-src/cn/src_doc.md
+++ b/docs-src/cn/src_doc.md
@@ -164,7 +164,7 @@ proxyServer.close();
   * 样例
 
   ```js
-    const AnyProxy = require('AnyProxy');
+    const AnyProxy = require('anyproxy');
     const exec = require('child_process').exec;
 
     if (!AnyProxy.utils.certMgr.ifRootCAFileExists()) {

--- a/docs-src/en/README.md
+++ b/docs-src/en/README.md
@@ -163,7 +163,7 @@ proxyServer.close();
   * Sample
 
   ```js
-    const AnyProxy = require('AnyProxy');
+    const AnyProxy = require('anyproxy');
     const exec = require('child_process').exec;
 
     if (!AnyProxy.utils.certMgr.ifRootCAFileExists()) {
@@ -521,8 +521,8 @@ module.exports = {
 anyproxy --rule rule_sample/sample_use_local_response.js
 ```
 ```js
-/* 
-  sample: 
+/*
+  sample:
     intercept all requests toward httpbin.org, use a local response
   test:
     curl http://httpbin.org/user-agent --proxy http://127.0.0.1:8001
@@ -551,8 +551,8 @@ module.exports = {
 anyproxy --rule rule_sample/sample_modify_request_header.js
 ```
 ```js
-/* 
-  sample: 
+/*
+  sample:
     modify the user-agent in requests toward httpbin.org
   test:
     curl http://httpbin.org/user-agent --proxy http://127.0.0.1:8001
@@ -640,8 +640,8 @@ module.exports = {
 anyproxy --rule rule_sample/sample_modify_request_protocol.js
 ```
 ```js
-/* 
-  sample: 
+/*
+  sample:
     redirect all http requests of httpbin.org to https
   test:
     curl 'http://httpbin.org/get?show_env=1' --proxy http://127.0.0.1:8001
@@ -670,8 +670,8 @@ module.exports = {
 anyproxy --rule rule_sample/sample_modify_response_statuscode.js
 ```
 ```js
-/* 
-  sample: 
+/*
+  sample:
     modify all status code of http://httpbin.org/ to 404
   test:
     curl -I 'http://httpbin.org/user-agent' --proxy http://127.0.0.1:8001
@@ -699,8 +699,8 @@ module.exports = {
 anyproxy --rule rule_sample/sample_modify_response_header.js
 ```
 ```js
-/* 
-  sample: 
+/*
+  sample:
     modify response header of http://httpbin.org/user-agent
   test:
     curl -I 'http://httpbin.org/user-agent' --proxy http://127.0.0.1:8001
@@ -728,8 +728,8 @@ module.exports = {
 anyproxy --rule rule_sample/sample_modify_response_data.js
 ```
 ```js
-/* 
-  sample: 
+/*
+  sample:
     modify response data of http://httpbin.org/user-agent
   test:
     curl 'http://httpbin.org/user-agent' --proxy http://127.0.0.1:8001

--- a/docs-src/en/src_doc.md
+++ b/docs-src/en/src_doc.md
@@ -163,7 +163,7 @@ proxyServer.close();
   * Sample
 
   ```js
-    const AnyProxy = require('AnyProxy');
+    const AnyProxy = require('anyproxy');
     const exec = require('child_process').exec;
 
     if (!AnyProxy.utils.certMgr.ifRootCAFileExists()) {


### PR DESCRIPTION
大小写敏感的操作系统下，会导致模块找不到的错误。