### PR TITLE
Add ca helper when run anyproxy -i

### DIFF
--- a/bin/anyproxy
+++ b/bin/anyproxy
@@ -4,9 +4,11 @@
 
 const program = require('commander'),
   color = require('colorful'),
+  co = require('co'),
   packageInfo = require('../package.json'),
-  ruleLoader = require('../lib/ruleLoader'),
   util = require('../lib/util'),
+  rootCACheck = require('./rootCaCheck'),
+  startServer = require('./startServer'),
   logUtil = require('../lib/log');
 
 program
@@ -33,85 +35,20 @@ if (program.clear) {
     process.exit(0);
   });
 } else {
-  const AnyProxy = require('../proxy.js');
-  let proxyServer;
-
-  if (program.silent) {
-    logUtil.setPrintStatus(false);
-  }
-
-  // load rule module
-  new Promise((resolve, reject) => {
-    if (program.rule) {
-      resolve(ruleLoader.requireModule(program.rule));
-    } else {
-      resolve(null);
-    }
-  })
-  .catch(e => {
-    logUtil.printLog('Failed to load rule file', logUtil.T_ERR);
-    logUtil.printLog(e, logUtil.T_ERR);
-    process.exit();
-  })
-
-  //start proxy
-  .then(ruleModule => {
-    proxyServer = new AnyProxy.ProxyServer({
-      type: 'http',
-      port: program.port || 8001,
-      throttle: program.throttle,
-      rule: ruleModule,
-      webInterface: {
-        enable: true,
-        webPort: program.web,
-      },
-      wsIntercept: program.wsIntercept,
-      forceProxyHttps: program.intercept,
-      dangerouslyIgnoreUnauthorized: !!program.ignoreUnauthorizedSsl,
-      silent: program.silent
-    });
-    // proxyServer.on('ready', () => {});
-    proxyServer.start();
-  })
-  .catch(e => {
-    logUtil.printLog(e, logUtil.T_ERR);
-    if (e && e.code) {
-      logUtil.printLog('code ' + e.code, logUtil.T_ERR);
-    }
-    logUtil.printLog(e.stack, logUtil.T_ERR);
-  });
-
-  process.on('exit', (code) => {
-    if (code > 0) {
-      logUtil.printLog('AnyProxy is about to exit with code: ' + code, logUtil.T_ERR);
+  co(function *() {
+    if (program.silent) {
+      logUtil.setPrintStatus(false);
     }
 
-    process.exit();
-  });
-
-  //exit cause ctrl+c
-  process.on('SIGINT', () => {
-    try {
-      proxyServer && proxyServer.close();
-    } catch (e) {
-      console.error(e);
-    }
-    process.exit();
-  });
-
-  process.on('uncaughtException', (err) => {
-    let errorTipText = 'got an uncaught exception, is there anything goes wrong in your rule file ?\n';
-    try {
-      if (err && err.stack) {
-        errorTipText += err.stack;
-      } else {
-        errorTipText += err;
+    if (program.intercept) {
+      try {
+        yield rootCACheck();
+      } catch (e) {
+        console.error(e);
       }
-    } catch (e) {}
-    logUtil.printLog(errorTipText, logUtil.T_ERR);
-    try {
-      proxyServer && proxyServer.close();
-    } catch (e) {}
-    process.exit();
-  });
+    }
+
+    return startServer(program);
+  })
 }
+

--- a/bin/rootCACheck.js
+++ b/bin/rootCACheck.js
@@ -1,0 +1,33 @@
+/**
+* check if root CA exists and installed
+* will prompt to generate when needed
+*/
+
+const thunkify = require('thunkify');
+const AnyProxy = require('../proxy');
+const logUtil = require('../lib/log');
+
+const certMgr = AnyProxy.utils.certMgr;
+
+function checkRootCAExists() {
+  return certMgr.isRootCAFileExists();
+}
+
+module.exports = function *() {
+  try {
+    if (!checkRootCAExists()) {
+      logUtil.warn('Missing root CA, generating now');
+      yield thunkify(certMgr.generateRootCA)();
+      yield certMgr.trustRootCA();
+    } else {
+      const isCATrusted = yield thunkify(certMgr.ifRootCATrusted)();
+      if (!isCATrusted) {
+        logUtil.warn('ROOT CA NOT INSTALLED YET');
+        yield certMgr.trustRootCA();
+      }
+    }
+  } catch (e) {
+    console.error(e);
+  }
+};
+

--- a/bin/startServer.js
+++ b/bin/startServer.js
@@ -1,0 +1,86 @@
+/**
+* start the AnyProxy server
+*/
+
+const ruleLoader = require('../lib/ruleLoader');
+const logUtil = require('../lib/log');
+const AnyProxy = require('../proxy');
+
+module.exports = function startServer(program) {
+  let proxyServer;
+  // load rule module
+  new Promise((resolve, reject) => {
+    if (program.rule) {
+      resolve(ruleLoader.requireModule(program.rule));
+    } else {
+      resolve(null);
+    }
+  })
+    .catch(e => {
+      logUtil.printLog('Failed to load rule file', logUtil.T_ERR);
+      logUtil.printLog(e, logUtil.T_ERR);
+      process.exit();
+    })
+
+    //start proxy
+    .then(ruleModule => {
+      proxyServer = new AnyProxy.ProxyServer({
+        type: 'http',
+        port: program.port || 8001,
+        throttle: program.throttle,
+        rule: ruleModule,
+        webInterface: {
+          enable: true,
+          webPort: program.web,
+        },
+        wsIntercept: program.wsIntercept,
+        forceProxyHttps: program.intercept,
+        dangerouslyIgnoreUnauthorized: !!program.ignoreUnauthorizedSsl,
+        silent: program.silent
+      });
+      // proxyServer.on('ready', () => {});
+      proxyServer.start();
+    })
+    .catch(e => {
+      logUtil.printLog(e, logUtil.T_ERR);
+      if (e && e.code) {
+        logUtil.printLog('code ' + e.code, logUtil.T_ERR);
+      }
+      logUtil.printLog(e.stack, logUtil.T_ERR);
+    });
+
+
+  process.on('exit', (code) => {
+    if (code > 0) {
+      logUtil.printLog('AnyProxy is about to exit with code: ' + code, logUtil.T_ERR);
+    }
+
+    process.exit();
+  });
+
+  //exit cause ctrl+c
+  process.on('SIGINT', () => {
+    try {
+      proxyServer && proxyServer.close();
+    } catch (e) {
+      console.error(e);
+    }
+    process.exit();
+  });
+
+  process.on('uncaughtException', (err) => {
+    let errorTipText = 'got an uncaught exception, is there anything goes wrong in your rule file ?\n';
+    try {
+      if (err && err.stack) {
+        errorTipText += err.stack;
+      } else {
+        errorTipText += err;
+      }
+    } catch (e) { }
+    logUtil.printLog(errorTipText, logUtil.T_ERR);
+    try {
+      proxyServer && proxyServer.close();
+    } catch (e) { }
+    process.exit();
+  });
+}

--- a/lib/certMgr.js
+++ b/lib/certMgr.js
@@ -85,9 +85,11 @@ crtMgr.trustRootCA = function *() {
       } else {
         console.error(result);
         logUtil.info('Failed to trust the root CA, please trust it manually');
+        util.guideToHomePage();
       }
     } else {
       logUtil.info('Please trust the root CA manually so https interception works');
+      util.guideToHomePage();
     }
   }
 

--- a/lib/certMgr.js
+++ b/lib/certMgr.js
@@ -1,11 +1,16 @@
 'use strict'
 
-const util = require('./util');
 const EasyCert = require('node-easy-cert');
 const co = require('co');
+const os = require('os');
+const inquirer = require('inquirer');
+
+const util = require('./util');
+const logUtil = require('./log');
 
 const options = {
   rootDirPath: util.getAnyProxyPath('certificates'),
+  inMemory: false,
   defaultCertAttrs: [
     { name: 'countryName', value: 'CN' },
     { name: 'organizationName', value: 'AnyProxy' },
@@ -52,6 +57,45 @@ crtMgr.getCAStatus = function *() {
       return result;
     }
   });
+}
+
+/**
+ * trust the root ca by command
+ */
+crtMgr.trustRootCA = function *() {
+  const platform = os.platform();
+  const rootCAPath = crtMgr.getRootCAFilePath();
+  const trustInquiry = [
+    {
+      type: 'list',
+      name: 'trustCA',
+      message: 'The rootCA is not trusted yet, install it to the trust store now?',
+      choices: ['Yes', "No, I'll do it myself"]
+    }
+  ];
+
+  if (platform === 'darwin') {
+    const answer = yield inquirer.prompt(trustInquiry);
+    if (answer.trustCA === 'Yes') {
+      logUtil.info('About to trust the root CA, this may requires your password');
+      // https://ss64.com/osx/security-cert.html
+      const result = util.execScriptSync(`sudo security add-trusted-cert -d -k /Library/Keychains/System.keychain ${rootCAPath}`);
+      if (result.status === 0) {
+        logUtil.info('Root CA install, you are ready to intercept the https now');
+      } else {
+        console.error(result);
+        logUtil.info('Failed to trust the root CA, please trust it manually');
+      }
+    } else {
+      logUtil.info('Please trust the root CA manually so https interception works');
+    }
+  }
+
+
+  if (/^win/.test(process.platform)) {
+    logUtil.info('You can install the root CA manually.');
+  }
+  logUtil.info('The root CA file path is: ' + crtMgr.getRootCAFilePath());
 }
 
 module.exports = crtMgr;

--- a/lib/log.js
+++ b/lib/log.js
@@ -58,7 +58,7 @@ function printLog(content, type) {
         return;
       }
 
-      console.error(color.magenta(`[AnyProxy WARN][${timeString}]: ` + content));
+      console.error(color.yellow(`[AnyProxy WARN][${timeString}]: ` + content));
       break;
     }
 
@@ -89,7 +89,7 @@ module.exports.warn = (content) => {
 };
 
 module.exports.error = (content) => {
-  printLog(content, LogLevelMap.error);
+  printLog(content, LogLevelMap.system_error);
 };
 
 module.exports.ruleError = (content) => {

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,7 +4,7 @@ const fs = require('fs'),
   path = require('path'),
   mime = require('mime-types'),
   color = require('colorful'),
-  crypto = require('crypto'),
+  child_process = require('child_process'),
   Buffer = require('buffer').Buffer,
   logUtil = require('./log');
 const networkInterfaces = require('os').networkInterfaces();
@@ -216,6 +216,8 @@ function deleteFolderContentsRecursive(dirPath, ifClearFolderItself) {
     throw new Error('can_not_delete_this_dir');
   }
 
+  console.info('==>>> delete cache ', dirPath);
+
   if (fs.existsSync(dirPath)) {
     fs.readdirSync(dirPath).forEach((file) => {
       const curPath = path.join(dirPath, file);
@@ -307,17 +309,18 @@ module.exports.isIpDomain = function (domain) {
   return ipReg.test(domain);
 };
 
-/**
-* To generic a Sec-WebSocket-Accept value
-* 1. append the `Sec-WebSocket-Key` request header with `matic string`
-* 2. get sha1 hash of the string
-* 3. get base64 of the sha1 hash
-*/
-module.exports.genericWsSecAccept = function (wsSecKey) {
-  // the string to generate the Sec-WebSocket-Accept
-  const magicString = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
-  const targetString = `${wsSecKey}${magicString}`;
-  const shasum = crypto.createHash('sha1');
-  shasum.update(targetString);
-  return shasum.digest('base64');
-}
+module.exports.execScriptSync = function (cmd) {
+  let stdout,
+    status = 0;
+  try {
+    stdout = child_process.execSync(cmd);
+  } catch (err) {
+    stdout = err.stdout;
+    status = err.status;
+  }
+
+  return {
+    stdout: stdout.toString(),
+    status
+  };
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -216,7 +216,7 @@ function deleteFolderContentsRecursive(dirPath, ifClearFolderItself) {
     throw new Error('can_not_delete_this_dir');
   }
 
-  console.info('==>>> delete cache ', dirPath);
+  logUtil.info('==>>> clearing cache ', dirPath);
 
   if (fs.existsSync(dirPath)) {
     fs.readdirSync(dirPath).forEach((file) => {
@@ -323,4 +323,8 @@ module.exports.execScriptSync = function (cmd) {
     stdout: stdout.toString(),
     status
   };
+};
+
+module.exports.guideToHomePage = function () {
+  logUtil.info('Refer to http://anyproxy.io for more detail');
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anyproxy",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "description": "A fully configurable HTTP/HTTPS proxy in Node.js",
   "main": "proxy.js",
   "bin": {
@@ -35,6 +35,7 @@
     "request": "^2.74.0",
     "stream-throttle": "^0.1.3",
     "svg-inline-react": "^1.0.2",
+    "thunkify": "^2.1.2",
     "whatwg-fetch": "^1.0.0",
     "ws": "^5.1.0"
   },
@@ -68,7 +69,6 @@
     "koa-send": "^3.2.0",
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
-    "memwatch-next": "^0.3.0",
     "node-simhash": "^0.1.0",
     "nodeunit": "^0.9.1",
     "phantom": "^4.0.0",


### PR DESCRIPTION
Check and help to generate the root CA when run in https interception mode, and install the CA after user's confirmation (Mac only for now)

1. refact the `bin/anyproxy`, split the *startServer* logic to the `startServer.js`， ref to: [bin/anyproxy](https://github.com/alibaba/anyproxy/blob/ca_helper/bin/anyproxy#L43)
2. create the `rootCACheck.js` mainly to do the CA check and help
3. add `trustRootCA` in the certMgr.js

The CA logic will only be worked when in https interception mode