### PR TITLE
Ensured that traffic forwarded to the local HTTPS server instances us…

### DIFF
--- a/lib/requestHandler.js
+++ b/lib/requestHandler.js
@@ -623,7 +623,7 @@ function getConnectReqHandler(userRule, recorder, httpsServerMgr) {
         // for ws request, redirect them to local ws server
         return interceptWsRequest ? localHttpServer : originServer;
       } else {
-        return httpsServerMgr.getSharedHttpsServer(host).then(serverInfo => ({ host: serverInfo.host, port: serverInfo.port }));
+        return httpsServerMgr.getSharedHttpsServer(host).then(serverInfo => ({ host: 'localhost', port: serverInfo.port }));
       }
     })
     .then((serverInfo) => {


### PR DESCRIPTION
…es localhost as the IP hostname

Without this change, any HTTPS traffic being forwarded will time out, as it is forwarded using the final hostname and the internal HTTPS server port number.