### PR TITLE
fix crashing issue when connection is reset

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -80,6 +80,15 @@ function normalizeInfo(id, info) {
   return singleRecord;
 }
 
+function getCacheFile(cachePath, filename, callback) {
+  const filepath = path.join(cachePath, filename);
+  if (filepath.indexOf(cachePath) !== 0) {
+    callback(new Error('invalid argument for accessing cache file'));
+  } else {
+    callback(null, filepath);
+  }
+}
+
 class Recorder extends events.EventEmitter {
   constructor(config) {
     super(config);
@@ -129,9 +138,10 @@ class Recorder extends events.EventEmitter {
     const cachePath = this.cachePath;
     if (id < 0) return;
     try {
-      const recordWsMessageFile = path.join(cachePath, WS_MESSAGE_FILE_PRFIX + id);
-
-      fs.appendFile(recordWsMessageFile, wsMessageStingify(message) + ',', () => {});
+      getCacheFile(cachePath, WS_MESSAGE_FILE_PRFIX + id, (error, recordWsMessageFile) => {
+        if (error) throw error;
+        fs.appendFile(recordWsMessageFile, wsMessageStingify(message) + ',', () => {});
+      });
     } catch (e) {
       console.error(e);
       logUtil.error(e.message + e.stack);
@@ -179,8 +189,10 @@ class Recorder extends events.EventEmitter {
     if (!id || typeof info.resBody === 'undefined') return;
     //add to body map
     //ignore image data
-    const bodyFile = path.join(cachePath, BODY_FILE_PRFIX + id);
-    fs.writeFile(bodyFile, info.resBody, () => {});
+    getCacheFile(cachePath, BODY_FILE_PRFIX + id, (error, bodyFile) => {
+      if (error) throw error;
+      fs.writeFile(bodyFile, info.resBody, () => {});
+    });
   }
 
   /**
@@ -195,12 +207,17 @@ class Recorder extends events.EventEmitter {
       cb && cb('');
     }
 
-    const bodyFile = path.join(cachePath, BODY_FILE_PRFIX + id);
-    fs.access(bodyFile, fs.F_OK || fs.R_OK, (err) => {
-      if (err) {
-        cb && cb(err);
+    getCacheFile(cachePath, BODY_FILE_PRFIX + id, (error, bodyFile) => {
+      if (error) {
+        cb && cb(error);
       } else {
-        fs.readFile(bodyFile, cb);
+        fs.access(bodyFile, fs.F_OK || fs.R_OK, (err) => {
+          if (err) {
+            cb && cb(err);
+          } else {
+            fs.readFile(bodyFile, cb);
+          }
+        });
       }
     });
   }
@@ -277,26 +294,31 @@ class Recorder extends events.EventEmitter {
       cb && cb([]);
     }
 
-    const wsMessageFile = path.join(cachePath, WS_MESSAGE_FILE_PRFIX + id);
-    fs.access(wsMessageFile, fs.F_OK || fs.R_OK, (err) => {
-      if (err) {
-        cb && cb(err);
+    getCacheFile(cachePath, WS_MESSAGE_FILE_PRFIX + id, (outerError, wsMessageFile) => {
+      if (outerError) {
+        cb && cb(outerError);
       } else {
-        fs.readFile(wsMessageFile, 'utf8', (error, content) => {
-          if (error) {
+        fs.access(wsMessageFile, fs.F_OK || fs.R_OK, (err) => {
+          if (err) {
             cb && cb(err);
-          }
-
-          try {
-            // remove the last dash "," if it has, since it's redundant
-            // and also add brackets to make it a complete JSON structure
-            content = `[${content.replace(/,$/, '')}]`;
-            const messages = JSON.parse(content);
-            cb(null, messages);
-          } catch (e) {
-            console.error(e);
-            logUtil.error(e.message + e.stack);
-            cb(e);
+          } else {
+            fs.readFile(wsMessageFile, 'utf8', (error, content) => {
+              if (error) {
+                cb && cb(err);
+              }
+    
+              try {
+                // remove the last dash "," if it has, since it's redundant
+                // and also add brackets to make it a complete JSON structure
+                content = `[${content.replace(/,$/, '')}]`;
+                const messages = JSON.parse(content);
+                cb(null, messages);
+              } catch (e) {
+                console.error(e);
+                logUtil.error(e.message + e.stack);
+                cb(e);
+              }
+            });
           }
         });
       }

--- a/lib/requestHandler.js
+++ b/lib/requestHandler.js
@@ -580,6 +580,9 @@ function getConnectReqHandler(userRule, recorder, httpsServerMgr) {
             resolve();
           }
         });
+        cltSocket.on('error', (e) => {
+          reject(e);
+        });
         cltSocket.on('end', () => {
           requestStream.push(null);
         });


### PR DESCRIPTION
应该可以解决 #408 #372 #370 和 #410 
重现方法：系统是 Mac 或 Windows 都可以，node 需要 v10。开启代理之后，访问一个页面，然后在加载完毕前访问新的页面或刷新，应该就会触发 ECONNRESET 的未捕获异常。
之前 node 8 版本是可以正常运行的，但是 node 10 不行，很可能是因为 node 10 引入了这个 commit：<https://github.com/nodejs/node/pull/18868/commits/6f3a1778becf71afaa42220af31599fbd2cb37ae#diff-e04bb2b2c80feabbca11f04983e000cd> 导致原先默认的 error 事件回调缺失，报错成了未捕获异常。
