### PR TITLE
fix: default wss port will cause service close

### DIFF
--- a/lib/requestHandler.js
+++ b/lib/requestHandler.js
@@ -694,7 +694,8 @@ function getWsHandler(userRule, recorder, wsClient, wsReq) {
     };
     const clientMsgQueue = [];
     const serverInfo = getWsReqInfo(wsReq);
-    const wsUrl = `${serverInfo.protocol}://${serverInfo.hostName}:${serverInfo.port}${serverInfo.path}`;
+    const serverInfoPort = serverInfo.port ? `:${serverInfo.port}` : '';
+    const wsUrl = `${serverInfo.protocol}://${serverInfo.hostName}${serverInfoPort}${serverInfo.path}`;
     const proxyWs = new WebSocket(wsUrl, '', {
       rejectUnauthorized: !self.dangerouslyIgnoreUnauthorized,
       headers: serverInfo.noWsHeaders


### PR DESCRIPTION
getWsHandler:

`serverInfo.port` may be `undefined`

The wss service will be closed