### PR TITLE
webInterface close -> callback()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ test/report
 doc_compiled.md
 docs-md/cn/doc.md
 docs-md/en/doc.md
+node_modules

--- a/lib/webInterface.js
+++ b/lib/webInterface.js
@@ -318,12 +318,13 @@ class webInterface extends events.EventEmitter {
     })
   }
 
-  close() {
+  close(callback) {
     this.server && this.server.close();
     this.wsServer && this.wsServer.closeAll();
     this.server = null;
     this.wsServer = null;
     this.proxyInstance = null;
+    callback();
   }
 }
 


### PR DESCRIPTION
webInterface的close中没有调用callback函数，导致proxy如果开启了webServerInstance，ProxyServer.close返回的promise没有被resolve。

