### PR TITLE
FIX #518 DELETE |  GET 等方法无法传递请求体

### DIFF
--- a/lib/requestHandler.js
+++ b/lib/requestHandler.js
@@ -197,6 +197,7 @@ function fetchRemoteResponse(protocol, options, reqData, config) {
       });
     });
 
+    proxyReq.useChunkedEncodingByDefault = true;
     proxyReq.on('error', reject);
     proxyReq.end(reqData);
   });


### PR DESCRIPTION
FIX #518 DELETE |  GET 等方法无法传递请求体