### PR TITLE
Support proxying custom WebSocket sub protocols

### DIFF
--- a/lib/requestHandler.js
+++ b/lib/requestHandler.js
@@ -215,6 +215,7 @@ function fetchRemoteResponse(protocol, options, reqData, config) {
 function getWsReqInfo(wsReq) {
   const headers = wsReq.headers || {};
   const host = headers.host;
+  const wsProtocol = headers['sec-websocket-protocol'] || '';
   const hostName = host.split(':')[0];
   const port = host.split(':')[1];
 
@@ -248,7 +249,8 @@ function getWsReqInfo(wsReq) {
     hostName: hostName,
     port: port,
     path: path,
-    protocol: isEncript ? 'wss' : 'ws'
+    protocol: isEncript ? 'wss' : 'ws',
+    wsProtocol: wsProtocol
   };
 }
 /**
@@ -712,7 +714,7 @@ function getWsHandler(userRule, recorder, wsClient, wsReq) {
     const serverInfo = getWsReqInfo(wsReq);
     const serverInfoPort = serverInfo.port ? `:${serverInfo.port}` : '';
     const wsUrl = `${serverInfo.protocol}://${serverInfo.hostName}${serverInfoPort}${serverInfo.path}`;
-    const proxyWs = new WebSocket(wsUrl, '', {
+    const proxyWs = new WebSocket(wsUrl, serverInfo.wsProtocol, {
       rejectUnauthorized: !self.dangerouslyIgnoreUnauthorized,
       headers: serverInfo.noWsHeaders
     });


### PR DESCRIPTION
This change allows protocols, like MQTT, that take advantage of WebSocket connections to be properly proxied by Anyproxy. In the current version, MQTT connections will connect and then immediately disconnect.

The standard `Sec-WebSocket-Protocol` header is used to set the correct sub protocol in the `new WebSocket()` constructor. If the header is not given, it will default to its currently hardcoded value.

Happy to make any adjustments and this should be a backwards-compatible change.