### PR TITLE
add cache option

### DIFF
--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -84,6 +84,7 @@ class Recorder extends events.EventEmitter {
   constructor(config) {
     super(config);
     this.globalId = 1;
+    this.fake = false;
     this.cachePath = getCacheDir();
     this.db = new Datastore();
 

--- a/lib/requestHandler.js
+++ b/lib/requestHandler.js
@@ -415,12 +415,14 @@ function getUserReqHandler(userRule, recorder) {
             req,
             startTime: new Date().getTime()
           };
-          resourceInfoId = recorder.appendRecord(resourceInfo);
+          if (!recorder.fake) {
+            resourceInfoId = recorder.appendRecord(resourceInfo);
+          }
         }
 
         try {
           resourceInfo.reqBody = reqData.toString(); //TODO: deal reqBody in webInterface.js
-          recorder && recorder.updateRecord(resourceInfoId, resourceInfo);
+          recorder && !recorder.fake && recorder.updateRecord(resourceInfoId, resourceInfo);
         } catch (e) { }
       })
 
@@ -505,7 +507,7 @@ function getUserReqHandler(userRule, recorder) {
 
         // console.info('===> resbody in record', resourceInfo);
 
-        recorder && recorder.updateRecord(resourceInfoId, resourceInfo);
+        recorder && !recorder.fake && recorder.updateRecord(resourceInfoId, resourceInfo);
       })
       .catch((e) => {
         logUtil.printLog(color.green('Send final response failed:' + e.message), logUtil.T_ERR);
@@ -619,7 +621,9 @@ function getConnectReqHandler(userRule, recorder, httpsServerMgr) {
             req,
             startTime: new Date().getTime()
           };
-          resourceInfoId = recorder.appendRecord(resourceInfo);
+          if (!recorder.fake) {
+            resourceInfoId = recorder.appendRecord(resourceInfo);
+          }
         }
       })
       .then(() => {
@@ -677,7 +681,7 @@ function getConnectReqHandler(userRule, recorder, httpsServerMgr) {
           resourceInfo.resBody = '';
           resourceInfo.length = 0;
 
-          recorder && recorder.updateRecord(resourceInfoId, resourceInfo);
+          recorder && !recorder.fake && recorder.updateRecord(resourceInfoId, resourceInfo);
         }
       })
       .catch(co.wrap(function *(error) {
@@ -726,7 +730,9 @@ function getWsHandler(userRule, recorder, wsClient, wsReq) {
         req: wsReq,
         startTime: new Date().getTime()
       });
-      resourceInfoId = recorder.appendRecord(resourceInfo);
+      if (!recorder.fake) {
+        resourceInfoId = recorder.appendRecord(resourceInfo);
+      }
     }
 
     /**
@@ -794,7 +800,7 @@ function getWsHandler(userRule, recorder, wsClient, wsReq) {
       };
 
       // resourceInfo.wsMessages.push(message);
-      recorder && recorder.updateRecordWsMessage(resourceInfoId, message);
+      recorder && !recorder.fake && recorder.updateRecordWsMessage(resourceInfoId, message);
     };
 
     proxyWs.onopen = () => {
@@ -815,7 +821,7 @@ function getWsHandler(userRule, recorder, wsClient, wsReq) {
       resourceInfo.resBody = '';
       resourceInfo.length = resourceInfo.resBody.length;
 
-      recorder && recorder.updateRecord(resourceInfoId, resourceInfo);
+      recorder && !recorder.fake && recorder.updateRecord(resourceInfoId, resourceInfo);
     });
 
     proxyWs.onerror = (e) => {


### PR DESCRIPTION
**add cache option**
the default/missing cache value is false, which means it does not store response body on local disk, so no longer worry about too much disk usage; when cache is false, the webinterface is forced to disable 

If you want to keep local cache, e.g the webInterface is needed, you can also set cache value to true

```
const options = {
  port: 8001,
  cache: false
};

const proxyServer = new AnyProxy.ProxyServer(options);
```