### PR TITLE
Add support for forwarding WebSocket

### DIFF
--- a/lib/requestHandler.js
+++ b/lib/requestHandler.js
@@ -728,7 +728,7 @@ function getWsHandler(userRule, recorder, wsClient, wsReq) {
       _req: wsReq
     };
 
-    userRule.beforeSendRequest(requestDetail).then(modifiedRequestDetail => {
+    Promise.resolve(userRule.beforeSendRequest(requestDetail)).then(modifiedRequestDetail => {
       const {
         protocol: wsProtocol,
         requestOptions: {
@@ -737,7 +737,7 @@ function getWsHandler(userRule, recorder, wsClient, wsReq) {
           path: wsPath,
           headers: wsHeaders
         }
-      } = modifiedWsUrl;
+      } = modifiedRequestDetail;
       const modifiedWsUrl = `${wsProtocol}://${wsHostname}${wsPort ? ':' + wsPort : ''}${wsPath}`;
       const proxyWs = new WebSocket(modifiedWsUrl, '', {
         rejectUnauthorized: !self.dangerouslyIgnoreUnauthorized,

--- a/lib/requestHandler.js
+++ b/lib/requestHandler.js
@@ -712,139 +712,167 @@ function getWsHandler(userRule, recorder, wsClient, wsReq) {
     const serverInfo = getWsReqInfo(wsReq);
     const serverInfoPort = serverInfo.port ? `:${serverInfo.port}` : '';
     const wsUrl = `${serverInfo.protocol}://${serverInfo.hostName}${serverInfoPort}${serverInfo.path}`;
-    const proxyWs = new WebSocket(wsUrl, '', {
-      rejectUnauthorized: !self.dangerouslyIgnoreUnauthorized,
+    const options = {
+      hostname: serverInfo.hostName,
+      port: serverInfoPort,
+      path: serverInfo.path,
+      method: wsReq.method,
       headers: serverInfo.noWsHeaders
-    });
-
-    if (recorder) {
-      Object.assign(resourceInfo, {
-        host: serverInfo.hostName,
-        method: 'WebSocket',
-        path: serverInfo.path,
-        url: wsUrl,
-        req: wsReq,
-        startTime: new Date().getTime()
-      });
-      resourceInfoId = recorder.appendRecord(resourceInfo);
-    }
-
-    /**
-    * store the messages before the proxy ws is ready
-    */
-    const sendProxyMessage = (event) => {
-      const message = event.data;
-      if (proxyWs.readyState === 1) {
-        // if there still are msg queue consuming, keep it going
-        if (clientMsgQueue.length > 0) {
-          clientMsgQueue.push(message);
-        } else {
-          proxyWs.send(message);
-        }
-      } else {
-        clientMsgQueue.push(message);
-      }
-    }
-
-    /**
-    * consume the message in queue when the proxy ws is not ready yet
-    * will handle them from the first one-by-one
-    */
-    const consumeMsgQueue = () => {
-      while (clientMsgQueue.length > 0) {
-        const message = clientMsgQueue.shift();
-        proxyWs.send(message);
-      }
-    }
-
-    /**
-    * When the source ws is closed, we need to close the target websocket.
-    * If the source ws is normally closed, that is, the code is reserved, we need to transfrom them
-    */
-    const getCloseFromOriginEvent = (event) => {
-      const code = event.code || '';
-      const reason = event.reason || '';
-      let targetCode = '';
-      let targetReason = '';
-      if (code >= 1004 && code <= 1006) {
-        targetCode = 1000; // normal closure
-        targetReason = `Normally closed. The origin ws is closed at code: ${code} and reason: ${reason}`;
-      } else {
-        targetCode = code;
-        targetReason = reason;
-      }
-
-      return {
-        code: targetCode,
-        reason: targetReason
-      }
-    }
-
-    /**
-    * consruct a message Record from message event
-    * @param @required {event} messageEvent the event from websockt.onmessage
-    * @param @required {boolean} isToServer whether the message is to or from server
-    *
-    */
-    const recordMessage = (messageEvent, isToServer) => {
-      const message = {
-        time: Date.now(),
-        message: messageEvent.data,
-        isToServer: isToServer
-      };
-
-      // resourceInfo.wsMessages.push(message);
-      recorder && recorder.updateRecordWsMessage(resourceInfoId, message);
     };
 
-    proxyWs.onopen = () => {
-      consumeMsgQueue();
-    }
+    const requestDetail = {
+      requestOptions: options,
+      protocol: serverInfo.protocol,
+      url: wsUrl,
+      requestData: Buffer.alloc(0),
+      _req: wsReq
+    };
 
-    // this event is fired when the connection is build and headers is returned
-    proxyWs.on('upgrade', (response) => {
-      resourceInfo.endTime = new Date().getTime();
-      const headers = response.headers;
-      resourceInfo.res = { //construct a self-defined res object
-        statusCode: response.statusCode,
-        headers: headers,
+    userRule.beforeSendRequest(requestDetail).then(modifiedRequestDetail => {
+      const {
+        protocol: wsProtocol,
+        requestOptions: {
+          hostname: wsHostname,
+          port: wsPort,
+          path: wsPath,
+          headers: wsHeaders
+        }
+      } = modifiedWsUrl;
+      const modifiedWsUrl = `${wsProtocol}://${wsHostname}${wsPort ? ':' + wsPort : ''}${wsPath}`;
+      const proxyWs = new WebSocket(modifiedWsUrl, '', {
+        rejectUnauthorized: !self.dangerouslyIgnoreUnauthorized,
+        headers: wsHeaders
+      });
+  
+      if (recorder) {
+        Object.assign(resourceInfo, {
+          host: serverInfo.hostName,
+          method: 'WebSocket',
+          path: serverInfo.path,
+          url: modifiedWsUrl,
+          req: wsReq,
+          startTime: new Date().getTime()
+        });
+        resourceInfoId = recorder.appendRecord(resourceInfo);
+      }
+  
+      /**
+      * store the messages before the proxy ws is ready
+      */
+      const sendProxyMessage = (event) => {
+        const message = event.data;
+        if (proxyWs.readyState === 1) {
+          // if there still are msg queue consuming, keep it going
+          if (clientMsgQueue.length > 0) {
+            clientMsgQueue.push(message);
+          } else {
+            proxyWs.send(message);
+          }
+        } else {
+          clientMsgQueue.push(message);
+        }
+      }
+  
+      /**
+      * consume the message in queue when the proxy ws is not ready yet
+      * will handle them from the first one-by-one
+      */
+      const consumeMsgQueue = () => {
+        while (clientMsgQueue.length > 0) {
+          const message = clientMsgQueue.shift();
+          proxyWs.send(message);
+        }
+      }
+  
+      /**
+      * When the source ws is closed, we need to close the target websocket.
+      * If the source ws is normally closed, that is, the code is reserved, we need to transfrom them
+      */
+      const getCloseFromOriginEvent = (event) => {
+        const code = event.code || '';
+        const reason = event.reason || '';
+        let targetCode = '';
+        let targetReason = '';
+        if (code >= 1004 && code <= 1006) {
+          targetCode = 1000; // normal closure
+          targetReason = `Normally closed. The origin ws is closed at code: ${code} and reason: ${reason}`;
+        } else {
+          targetCode = code;
+          targetReason = reason;
+        }
+  
+        return {
+          code: targetCode,
+          reason: targetReason
+        }
+      }
+  
+      /**
+      * consruct a message Record from message event
+      * @param @required {event} messageEvent the event from websockt.onmessage
+      * @param @required {boolean} isToServer whether the message is to or from server
+      *
+      */
+      const recordMessage = (messageEvent, isToServer) => {
+        const message = {
+          time: Date.now(),
+          message: messageEvent.data,
+          isToServer: isToServer
+        };
+  
+        // resourceInfo.wsMessages.push(message);
+        recorder && recorder.updateRecordWsMessage(resourceInfoId, message);
       };
-
-      resourceInfo.statusCode = response.statusCode;
-      resourceInfo.resHeader = headers;
-      resourceInfo.resBody = '';
-      resourceInfo.length = resourceInfo.resBody.length;
-
-      recorder && recorder.updateRecord(resourceInfoId, resourceInfo);
-    });
-
-    proxyWs.onerror = (e) => {
-      // https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes
-      wsClient.close(1001, e.message);
-      proxyWs.close(1001);
-    }
-
-    proxyWs.onmessage = (event) => {
-      recordMessage(event, false);
-      wsClient.readyState === 1 && wsClient.send(event.data);
-    }
-
-    proxyWs.onclose = (event) => {
-      logUtil.debug(`proxy ws closed with code: ${event.code} and reason: ${event.reason}`);
-      const targetCloseInfo = getCloseFromOriginEvent(event);
-      wsClient.readyState !== 3 && wsClient.close(targetCloseInfo.code, targetCloseInfo.reason);
-    }
-
-    wsClient.onmessage = (event) => {
-      recordMessage(event, true);
-      sendProxyMessage(event);
-    }
-
-    wsClient.onclose = (event) => {
-      logUtil.debug(`original ws closed with code: ${event.code} and reason: ${event.reason}`);
-      const targetCloseInfo = getCloseFromOriginEvent(event);
-      proxyWs.readyState !== 3 && proxyWs.close(targetCloseInfo.code, targetCloseInfo.reason);
-    }
+  
+      proxyWs.onopen = () => {
+        consumeMsgQueue();
+      }
+  
+      // this event is fired when the connection is build and headers is returned
+      proxyWs.on('upgrade', (response) => {
+        resourceInfo.endTime = new Date().getTime();
+        const headers = response.headers;
+        resourceInfo.res = { //construct a self-defined res object
+          statusCode: response.statusCode,
+          headers: headers,
+        };
+  
+        resourceInfo.statusCode = response.statusCode;
+        resourceInfo.resHeader = headers;
+        resourceInfo.resBody = '';
+        resourceInfo.length = resourceInfo.resBody.length;
+  
+        recorder && recorder.updateRecord(resourceInfoId, resourceInfo);
+      });
+  
+      proxyWs.onerror = (e) => {
+        // https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes
+        wsClient.close(1001, e.message);
+        proxyWs.close(1001);
+      }
+  
+      proxyWs.onmessage = (event) => {
+        recordMessage(event, false);
+        wsClient.readyState === 1 && wsClient.send(event.data);
+      }
+  
+      proxyWs.onclose = (event) => {
+        logUtil.debug(`proxy ws closed with code: ${event.code} and reason: ${event.reason}`);
+        const targetCloseInfo = getCloseFromOriginEvent(event);
+        wsClient.readyState !== 3 && wsClient.close(targetCloseInfo.code, targetCloseInfo.reason);
+      }
+  
+      wsClient.onmessage = (event) => {
+        recordMessage(event, true);
+        sendProxyMessage(event);
+      }
+  
+      wsClient.onclose = (event) => {
+        logUtil.debug(`original ws closed with code: ${event.code} and reason: ${event.reason}`);
+        const targetCloseInfo = getCloseFromOriginEvent(event);
+        proxyWs.readyState !== 3 && proxyWs.close(targetCloseInfo.code, targetCloseInfo.reason);
+      }
+    })
   } catch (e) {
     logUtil.debug('WebSocket Proxy Error:' + e.message);
     logUtil.debug(e.stack);


### PR DESCRIPTION
Add support for forwarding WebSocket connections in `beforeSendRequest`, but modifying WebSocket message is NOT supported.

 e.g.
```javascript
// rule.js
module.exports = {
  async beforeSendRequest(requestDetail) {
    const {
      protocol,
      requestOptions: { headers },
    } = requestDetail;

    // This example will forward every WebSocket to 127.0.0.1:8800
    // Replace with your own conditions
    if (protocol === 'ws' || protocol === 'wss') {
      return {
        protocol: 'ws',
        requestOptions: {
          hostname: '127.0.0.1',
          port: '8800',
          path: '/',
          headers,
        },
      };
    }

    return requestDetail;
  },
  async beforeDealHttpsRequest(requestDetail) {
    return true;
  },
};
```

```javascript
// ws.js
const WebSocket = require('ws');

const server = new WebSocket.Server({
  port: 8800,
});

server.on('connection', ws => {
  ws.on('message', msg => {
    ws.send(msg);
  });
});
```