### PR TITLE
update secureOptions parameter for https server

### DIFF
--- a/lib/httpsServerMgr.js
+++ b/lib/httpsServerMgr.js
@@ -68,7 +68,7 @@ function createHttpsSNIServer(port, handler) {
 
   return new Promise((resolve) => {
     const server = https.createServer({
-      secureOptions: constants.SSL_OP_NO_SSLv3 || constants.SSL_OP_NO_TLSv1,
+      secureOptions: constants.SSL_OP_NO_SSLv3 | constants.SSL_OP_NO_TLSv1,
       SNICallback: SNIPrepareCert,
     }, handler).listen(port);
     resolve(server);
@@ -82,7 +82,7 @@ function createHttpsIPServer(ip, port, handler) {
     certMgr.getCertificate(ip, (err, keyContent, crtContent) => {
       if (err) return reject(err);
       const server = https.createServer({
-        secureOptions: constants.SSL_OP_NO_SSLv3 || constants.SSL_OP_NO_TLSv1,
+        secureOptions: constants.SSL_OP_NO_SSLv3 | constants.SSL_OP_NO_TLSv1,
         key: keyContent,
         cert: crtContent,
       }, handler).listen(port);


### PR DESCRIPTION
Hello,

I’m a security researcher at [r2c](https://r2c.dev (https://r2c.dev/)). We work with industry experts to write code checks for bugs in open source.

Problem:
I found that the https server don't disallow TLS v1 as it intended to do
https://github.com/alibaba/anyproxy/blob/b93f948107b956e07c7b68faeff0c777a1f50486/lib/httpsServerMgr.js#L71
https://github.com/alibaba/anyproxy/blob/b93f948107b956e07c7b68faeff0c777a1f50486/lib/httpsServerMgr.js#L85

`TLS v1` is deprecated due to POODLE, man in the middle attacks, and other vulnerabilities.

Fix:
This is happens because TLS stack (OpenSSL) requires that the options are combined with **bitwise OR** while **logical OR** is used

```javascript
// this is how it should be
secureOptions: constants.SSL_OP_NO_SSLv3 | constants.SSL_OP_NO_TLSv1

// this is how it is used now
secureOptions: constants.SSL_OP_NO_SSLv3 || constants.SSL_OP_NO_TLSv1
```

in this case only `constants.SSL_OP_NO_SSLv3` is passed to `secureOptions` allowing connections with TLS v1

https://stackoverflow.com/questions/40434934/how-to-disable-the-ssl-3-0-and-tls-1-0-in-nodejs

We have a tool called [Semgrep](https://semgrep.dev (https://semgrep.dev/)) you can use for your project that continuously detects problems like this one. Semgrep is also available as a [GitHub Action](https://github.com/marketplace/actions/semgrep-action) to make it easy to set up. The check that identified this bug is available in Semgrep by using https://semgrep.dev/p/colleend.insecure-transport-nodejs

Thanks, and I hope this helps! Let me know if you have any questions.
