### PR TITLE
Delete duplicated Constant.js uppercase variant

### DIFF
--- a/web/src/common/Constant.js
+++ b/web/src/common/Constant.js
@@ -1,9 +1,0 @@
-/**
-* define all constant variables here
-*/
-
-module.exports.MenuKeyMap = {
-    RECORD_FILTER: 'RECORD_FILTER',
-    MAP_LOCAL: 'MAP_LOCAL',
-    ROOT_CA: 'ROOT_CA'
-};


### PR DESCRIPTION
Delete uppercase variant of Constant.js because MacOs doesn't support two files with names which the only difference is the casing