### PR TITLE
Set minimum node version to 10.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,6 @@
   "author": "ottomao@gmail.com",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.12.0"
   }
 }


### PR DESCRIPTION
The recursive option was added to `fs.mkdirSync` in node 10.12.0. It's used in https://github.com/alibaba/anyproxy/pull/562 for creating the temp directory.